### PR TITLE
 Removed the definition of private functions

### DIFF
--- a/src/tomee_cli/configuration/mail_resource.clj
+++ b/src/tomee_cli/configuration/mail_resource.clj
@@ -18,16 +18,16 @@
             [clojure.java.io :refer :all :as io])
   (:gen-class))
 
-(defn- read-tomee-xml [tomee-xml-file]
+(defn read-tomee-xml [tomee-xml-file]
   (xml/parse (io/as-file tomee-xml-file)))
 
-(defn- define-mail-resource
+(defn define-mail-resource
   "Define a mail resorce"
   [id host port protocol auth user password]
   (let [content (str "\nmail.smtp.host="host"\nmail.smtp.port="port"\nmail.transport.protocol="protocol"\nmail.smtp.auth="auth"\nmail.smtp.user="user"\npassword="password"\n")]
   {:tag :Resource :attrs {:id (str id) :type "javax.mail.Session"} :content [content]}))
 
-(defn- add-resource-in-tomee-xml [resource tomee-xml]
+(defn add-resource-in-tomee-xml [resource tomee-xml]
   (assoc tomee-xml :content resource))
 
 (defn create-mail-resource

--- a/src/tomee_cli/core.clj
+++ b/src/tomee_cli/core.clj
@@ -15,8 +15,8 @@
 (ns ^{:author "Daniel Cunha (soro) <daniel.cunha@bitmaker-software.com>,
                Hildeberto Mendonça <me@hildeberto.com>"}
   tomee-cli.core
-  (:require [tomee-cli.execution :refer :all]
-            [tomee-cli.configuration.mail-resource :refer :all])
+  (:require [tomee-cli.execution :refer (startup shutdown)]
+            [tomee-cli.configuration.mail-resource :refer (create-mail-resource)])
   (:gen-class))
 
 ;;(defn -main

--- a/src/tomee_cli/execution.clj
+++ b/src/tomee_cli/execution.clj
@@ -18,7 +18,7 @@
   (:require [clojure.java.shell :refer (sh)])
   (:gen-class))
 
-(defn- windows?
+(defn windows?
   "Verify if the operation system is windows or not"
   [] (= (.toLowerCase (System/getProperty "os.name")) "windows"))
 


### PR DESCRIPTION
Private functions make them difficult to be tested. This change remove
all private functions (from execution.clj and mail_resource.clj) and
considers the possibility of explicitly declaring a subset of functions
(core.clj) from other namespaces to achieve the same result.